### PR TITLE
Add SignUp OTP resend confirmation code feature

### DIFF
--- a/src/components/SignUp.vue
+++ b/src/components/SignUp.vue
@@ -114,7 +114,7 @@ export default {
       authCode: '',
       phase: 0,
       errorMessage: undefined,
-      confirmationCodeCooldownSecond: 0
+      confirmationCodeCooldownSecond: 30 
     }
   }
 }


### PR DESCRIPTION
Changes:
- Add feature to allow user can re-send sign up confirmation code
- The resend code will have default cooldown period (90 seconds)

[1] https://docs.amplify.aws/lib/auth/emailpassword/q/platform/js/#re-send-sign-up-confirmation-code